### PR TITLE
Fixing cdn links

### DIFF
--- a/Landing Page/angular-landing-page/src/index.html
+++ b/Landing Page/angular-landing-page/src/index.html
@@ -13,7 +13,7 @@
   />
   <link
     rel="stylesheet"
-    href="https://raw.githubusercontent.com/creativetimofficial/tailwind-starter-kit/master/compiled-tailwind.min.css"
+    href="https://cdn.jsdelivr.net/gh/creativetimofficial/tailwind-starter-kit/compiled-tailwind.min.css"
   />
   <title>Landing | Tailwind Starter Kit by Creative Tim</title>
 </head>

--- a/Landing Page/html-landing-page/landing.html
+++ b/Landing Page/html-landing-page/landing.html
@@ -16,7 +16,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://raw.githubusercontent.com/creativetimofficial/tailwind-starter-kit/master/compiled-tailwind.min.css"
+      href="https://cdn.jsdelivr.net/gh/creativetimofficial/tailwind-starter-kit/compiled-tailwind.min.css"
     />
     <title>Landing | Tailwind Starter Kit by Creative Tim</title>
   </head>

--- a/Landing Page/react-landing-page/public/index.html
+++ b/Landing Page/react-landing-page/public/index.html
@@ -30,7 +30,7 @@
     -->
     <link
       rel="stylesheet"
-      href="https://raw.githubusercontent.com/creativetimofficial/tailwind-starter-kit/master/compiled-tailwind.min.css"
+      href="https://cdn.jsdelivr.net/gh/creativetimofficial/tailwind-starter-kit/compiled-tailwind.min.css"
     />
     <title>Landing | Tailwind Starter Kit by Creative Tim</title>
   </head>

--- a/Landing Page/vuejs-landing-page/public/index.html
+++ b/Landing Page/vuejs-landing-page/public/index.html
@@ -12,7 +12,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://raw.githubusercontent.com/creativetimofficial/tailwind-starter-kit/master/compiled-tailwind.min.css"
+      href="https://cdn.jsdelivr.net/gh/creativetimofficial/tailwind-starter-kit/compiled-tailwind.min.css"
     />
     <title>Landing | Tailwind Starter Kit by Creative Tim</title>
   </head>

--- a/Login Page/angular-login-page/src/index.html
+++ b/Login Page/angular-login-page/src/index.html
@@ -13,7 +13,7 @@
   />
   <link
     rel="stylesheet"
-    href="https://raw.githubusercontent.com/creativetimofficial/tailwind-starter-kit/master/compiled-tailwind.min.css"
+    href="https://cdn.jsdelivr.net/gh/creativetimofficial/tailwind-starter-kit/compiled-tailwind.min.css"
   />
   <title>Login | Tailwind Starter Kit by Creative Tim</title>
 </head>

--- a/Login Page/html-login-page/login.html
+++ b/Login Page/html-login-page/login.html
@@ -16,7 +16,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://raw.githubusercontent.com/creativetimofficial/tailwind-starter-kit/master/compiled-tailwind.min.css"
+      href="https://cdn.jsdelivr.net/gh/creativetimofficial/tailwind-starter-kit/compiled-tailwind.min.css"
     />
     <title>Login | Tailwind Starter Kit by Creative Tim</title>
   </head>

--- a/Login Page/react-login-page/public/index.html
+++ b/Login Page/react-login-page/public/index.html
@@ -30,7 +30,7 @@
     -->
     <link
       rel="stylesheet"
-      href="https://raw.githubusercontent.com/creativetimofficial/tailwind-starter-kit/master/compiled-tailwind.min.css"
+      href="https://cdn.jsdelivr.net/gh/creativetimofficial/tailwind-starter-kit/compiled-tailwind.min.css"
     />
     <title>Landing | Tailwind Starter Kit by Creative Tim</title>
   </head>

--- a/Login Page/vuejs-login-page/public/index.html
+++ b/Login Page/vuejs-login-page/public/index.html
@@ -12,7 +12,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://raw.githubusercontent.com/creativetimofficial/tailwind-starter-kit/master/compiled-tailwind.min.css"
+      href="https://cdn.jsdelivr.net/gh/creativetimofficial/tailwind-starter-kit/compiled-tailwind.min.css"
     />
     <title>Login | Tailwind Starter Kit by Creative Tim</title>
   </head>

--- a/Profile Page/angular-profile-page/src/index.html
+++ b/Profile Page/angular-profile-page/src/index.html
@@ -13,7 +13,7 @@
   />
   <link
     rel="stylesheet"
-    href="https://raw.githubusercontent.com/creativetimofficial/tailwind-starter-kit/master/compiled-tailwind.min.css"
+    href="https://cdn.jsdelivr.net/gh/creativetimofficial/tailwind-starter-kit/compiled-tailwind.min.css"
   />
   <title>Profile | Tailwind Starter Kit by Creative Tim</title>
 </head>

--- a/Profile Page/html-profile-page/profile.html
+++ b/Profile Page/html-profile-page/profile.html
@@ -16,7 +16,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://raw.githubusercontent.com/creativetimofficial/tailwind-starter-kit/master/compiled-tailwind.min.css"
+      href="https://cdn.jsdelivr.net/gh/creativetimofficial/tailwind-starter-kit/compiled-tailwind.min.css"
     />
     <title>Profile | Tailwind Starter Kit by Creative Tim</title>
   </head>

--- a/Profile Page/react-profile-page/public/index.html
+++ b/Profile Page/react-profile-page/public/index.html
@@ -30,7 +30,7 @@
     -->
     <link
       rel="stylesheet"
-      href="https://raw.githubusercontent.com/creativetimofficial/tailwind-starter-kit/master/compiled-tailwind.min.css"
+      href="https://cdn.jsdelivr.net/gh/creativetimofficial/tailwind-starter-kit/compiled-tailwind.min.css"
     />
     <title>Profile | Tailwind Starter Kit by Creative Tim</title>
   </head>

--- a/Profile Page/vuejs-profile-page/public/index.html
+++ b/Profile Page/vuejs-profile-page/public/index.html
@@ -12,7 +12,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://raw.githubusercontent.com/creativetimofficial/tailwind-starter-kit/master/compiled-tailwind.min.css"
+      href="https://cdn.jsdelivr.net/gh/creativetimofficial/tailwind-starter-kit/compiled-tailwind.min.css"
     />
     <title>Profile | Tailwind Starter Kit by Creative Tim</title>
   </head>


### PR DESCRIPTION
The current link for the tailwind compiled CSS hosted on GitHub is getting cors error, this PR update the link to the same as the landing page